### PR TITLE
Refactor: 온보딩에서 로그인뷰 분리

### DIFF
--- a/Sources/Coordinators/LoginCoordinator.swift
+++ b/Sources/Coordinators/LoginCoordinator.swift
@@ -20,41 +20,33 @@ public class LoginCoordinator : Coordinator {
     }
     
     public func start() {
-        
-        let authUseCase = DIContainer.shared.resolve(AuthUseCase.self)!
-        let loginService = LoginService(authUseCase: authUseCase)
-        
-        let viewModel = LoginViewModel(loginService: loginService)
-        
         //온보딩 로그인 분기 설정
-        if UserDefaultsManager.isFirstTime {
-            UserDefaultsManager.isFirstTime = false
-            let loginViewController = LoginViewController(viewModel: viewModel)
-            
-            loginViewController.coordinator = self
-            navigationController.pushViewController(loginViewController, animated: true)
-            loginService.window = navigationController.view.window
-        } else {
-            let loginViewController = OnBoardingViewController(viewModel: viewModel)
-            
-            loginViewController.coordinator = self
-            navigationController.pushViewController(loginViewController, animated: true)
-            loginService.window = navigationController.view.window
+        // NOTE: 현재 온보딩 테스트 중이므로 조건 반전(!) 적용함.
+        // 실제 서비스 배포 전에는 `if UserDefaultsManager.isFirstTime` 로 수정 필요.
+        if !UserDefaultsManager.isFirstTime {
+            let onBoardingViewController = OnBoardingViewController()
+            onBoardingViewController.coordinator = self
+            navigationController.pushViewController(onBoardingViewController, animated: true)
+        }
+        else {
+            showLogin()
         }
     }
 }
 
+//MARK: - Login Delegate
+
 extension LoginCoordinator : LoginDelegate {
-    public func moveToTabbar() {
-        let appCoordinator = self.parentCoordiantor as! AppCoordinator
-        appCoordinator.startTabbarScene()
-        self.parentCoordiantor?.childDidFinish(self)
-        
-        //자동 Login 설정
-        UserDefaultsManager.isLoggined = true
-        //LoginView 제거해주기
-        self.navigationController.viewControllers.removeFirst()
-    }
+//    public func moveToTabbar() {
+//        let appCoordinator = self.parentCoordiantor as! AppCoordinator
+//        appCoordinator.startTabbarScene()
+//        self.parentCoordiantor?.childDidFinish(self)
+//        
+//        //자동 Login 설정
+//        UserDefaultsManager.isLoggined = true
+//        //LoginView 제거해주기
+//        self.navigationController.viewControllers.removeFirst()
+//    }
     
     public func moveToProfileSetting() {
         let appCoordinator = self.parentCoordiantor as! AppCoordinator
@@ -65,5 +57,27 @@ extension LoginCoordinator : LoginDelegate {
         profileSettingCoordinator.start()
         
         self.parentCoordiantor?.childDidFinish(self)
+    }
+}
+
+//MARK: - Onboarding Flow
+
+extension LoginCoordinator {
+    
+    private func makeLoginViewModel() -> LoginViewModel {
+        let authUseCase = DIContainer.shared.resolve(AuthUseCase.self)!
+        let loginService = LoginService(authUseCase: authUseCase)
+        loginService.window = navigationController.view.window
+        return LoginViewModel(loginService: loginService)
+    }
+    
+    public func showLogin() {
+        let viewModel = makeLoginViewModel()
+        
+        UserDefaultsManager.isFirstTime = false
+        let loginViewController = LoginViewController(viewModel: viewModel)
+        
+        loginViewController.coordinator = self
+        navigationController.pushViewController(loginViewController, animated: true)
     }
 }

--- a/Sources/Coordinators/LoginCoordinator.swift
+++ b/Sources/Coordinators/LoginCoordinator.swift
@@ -24,9 +24,7 @@ public class LoginCoordinator : Coordinator {
         // NOTE: 현재 온보딩 테스트 중이므로 조건 반전(!) 적용함.
         // 실제 서비스 배포 전에는 `if UserDefaultsManager.isFirstTime` 로 수정 필요.
         if !UserDefaultsManager.isFirstTime {
-            let onBoardingViewController = OnBoardingViewController()
-            onBoardingViewController.coordinator = self
-            navigationController.pushViewController(onBoardingViewController, animated: true)
+            showOnBoarding()
         }
         else {
             showLogin()
@@ -60,7 +58,7 @@ extension LoginCoordinator : LoginDelegate {
     }
 }
 
-//MARK: - Onboarding Flow
+//MARK: - Onboarding, Login Flow
 
 extension LoginCoordinator {
     
@@ -69,6 +67,12 @@ extension LoginCoordinator {
         let loginService = LoginService(authUseCase: authUseCase)
         loginService.window = navigationController.view.window
         return LoginViewModel(loginService: loginService)
+    }
+    
+    public func showOnBoarding() {
+        let onBoardingViewController = OnBoardingViewController()
+        onBoardingViewController.coordinator = self
+        navigationController.pushViewController(onBoardingViewController, animated: true)
     }
     
     public func showLogin() {

--- a/Sources/LoginFeature/LoginScreen/View/BaseOnBoarding.swift
+++ b/Sources/LoginFeature/LoginScreen/View/BaseOnBoarding.swift
@@ -88,7 +88,7 @@ class BaseOnBoarding: BaseUIView {
         
         mainLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(CGFloat(126).adjustedH)
+            make.top.equalToSuperview().offset(CGFloat(134).adjustedH)
         }
         
         subLabel1.snp.makeConstraints { make in

--- a/Sources/LoginFeature/LoginScreen/ViewController/LoginViewController.swift
+++ b/Sources/LoginFeature/LoginScreen/ViewController/LoginViewController.swift
@@ -22,7 +22,7 @@ import RxSwift
 import UIKit
 
 public protocol LoginDelegate {
-    func moveToTabbar()
+//    func moveToTabbar()
     func moveToProfileSetting()
 }
 


### PR DESCRIPTION
- 온보딩 5번째 로그인뷰 제거 
 -> 온보딩 4페이지에 confirm버튼 추가 
 -> LoginCoordinator에 onboardingVC view navigate 로직 추가
: OnBoardingCoordinator 만들어도 로그인뷰로 이동하는 로직만 있고, login쪽에서 겹치는 로직이 있어서 거기로 연결

- 온보딩페이지 컴포넌트 간격 조정